### PR TITLE
#10 empty、not疑似クラス

### DIFF
--- a/10/css/styles.css
+++ b/10/css/styles.css
@@ -1,0 +1,8 @@
+/* li:empty {
+    background: skyblue;
+} */
+
+
+li:not(:empty) {
+    background: skyblue;
+}

--- a/10/index.html
+++ b/10/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSSの練習</title>
+    <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+    <ul>
+        <li>項目</li>
+        <li></li>
+        <li> </li>
+        <li>
+            
+        </li>
+        <li><!-- コメント --></li>
+        <li>項目</li>
+    </ul>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@
  https://github.com/Shirahamah/dotinstall_basic_css_selectors/issues/7
 - [x] #08 :nth-child擬似クラスを使おう  
   https://github.com/Shirahamah/dotinstall_basic_css_selectors/issues/8
-- [ ] #09 :nth-of-type擬似クラスを使おう  
-- [ ] #10 :empty､:not擬似クラスを使おう  
+- [x] #09 :nth-of-type擬似クラスを使おう  
+  https://github.com/Shirahamah/dotinstall_basic_css_selectors/issues/9
+- [x] #10 :empty､:not擬似クラスを使おう  
+  https://github.com/Shirahamah/dotinstall_basic_css_selectors/issues/10
 - [ ] #11 詳細度を計算してみよう  
 - [ ] #12 優先されるスタイルを確認しよう   


### PR DESCRIPTION
#10 完了しました。
- README
https://github.com/Shirahamah/dotinstall_basic_css_selectors/blob/%2310-empty%E3%80%81not%E7%96%91%E4%BC%BC%E3%82%AF%E3%83%A9%E3%82%B9/README.md#%E8%A9%B3%E8%A7%A3css-%E3%82%BB%E3%83%AC%E3%82%AF%E3%82%BF%E3%83%BC%E7%B7%A8-%E5%85%A812%E5%9B%9E-%E9%80%B2%E6%8D%97%E7%A2%BA%E8%AA%8D

### 内容
- liでコンテンツを追加
- 項目を空にして、liに:emptyで背景色を指定
- 半角空白、改行をいれて:emptyの動きを確認
- :not(:empty)でから出ない要素を指定